### PR TITLE
ext2fs: Fix issue with zero size getblk() call

### DIFF
--- a/sys/fs/ext2fs/ext2_bmap.c
+++ b/sys/fs/ext2fs/ext2_bmap.c
@@ -156,13 +156,15 @@ readindir(struct vnode *vp, e2fs_lbn_t lbn, e2fs_daddr_t daddr, struct buf **bpp
 {
 	struct buf *bp;
 	struct mount *mp;
+	struct m_ext2fs *fs;
 	struct ext2mount *ump;
 	int error;
 
 	mp = vp->v_mount;
 	ump = VFSTOEXT2(mp);
+	fs = ump->um_e2fs;
 
-	bp = getblk(vp, lbn, mp->mnt_stat.f_iosize, 0, 0, 0);
+	bp = getblk(vp, lbn, fs->e2fs_bsize, 0, 0, 0);
 	if ((bp->b_flags & B_CACHE) == 0) {
 		KASSERT(daddr != 0,
 		    ("readindir: indirect block not in cache"));
@@ -189,6 +191,10 @@ readindir(struct vnode *vp, e2fs_lbn_t lbn, e2fs_daddr_t daddr, struct buf **bpp
 		}
 	}
 	*bpp = bp;
+
+	printf("==== readindir():inumber=%lx,buf=%p,bcache=%d,lbn=%lx,daddr=%x,f_iosize=%lx,bsize=%x\n",
+	    (uint64_t)0, bp, bp->b_flags & B_CACHE, lbn, daddr, mp->mnt_stat.f_iosize, fs->e2fs_bsize);
+
 	return (0);
 }
 


### PR DESCRIPTION
The block size passed to getblk() function had zero value, mean mp->mnt_stat.f_iosize field is zero because no ext2_statfs() calls were initiated by OS in the end of the mount procedure. Use fs->e2fs_bsize value instead, because it is already initialized at this point.